### PR TITLE
Hcs keyvals from csv

### DIFF
--- a/omero/annotation_scripts/KeyVal_from_csv.py
+++ b/omero/annotation_scripts/KeyVal_from_csv.py
@@ -225,7 +225,7 @@ def annotate_object(conn, obj, header, row, cols_to_ignore):
 
     print("Adding kv:")
     for i in range(len(row)):
-        if i in cols_to_ignore:
+        if i in cols_to_ignore or i >= len(header):
             continue
         key = header[i].strip()
         vals = row[i].strip().split(';')

--- a/omero/annotation_scripts/KeyVal_from_csv.py
+++ b/omero/annotation_scripts/KeyVal_from_csv.py
@@ -53,7 +53,6 @@ from collections import OrderedDict
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 def get_existing_map_annotations( obj ):
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    print("getting the existing kv's")
     ord_dict = OrderedDict()
     for ann in obj.listAnnotations():
         if( isinstance(ann, omero.gateway.MapAnnotationWrapper) ):
@@ -65,14 +64,14 @@ def get_existing_map_annotations( obj ):
     return ord_dict
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-def remove_map_annotations(conn, dtype, Id ):
+def remove_map_annotations(conn, object):
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    image = conn.getObject(dtype,int(Id))
-    namespace = omero.constants.metadata.NSCLIENTMAPANNOTATION
+    # image = conn.getObject(dtype,int(Id))
+    # namespace = omero.constants.metadata.NSCLIENTMAPANNOTATION
 
-    filename = image.getName()
+    # filename = image.getName()
 
-    anns = list( image.listAnnotations())
+    anns = list( object.listAnnotations())
     mapann_ids = [ann.id for ann in anns
          if isinstance(ann, omero.gateway.MapAnnotationWrapper) ]
 
@@ -106,9 +105,10 @@ def get_original_file(omero_object, file_ann_id=None):
     return file_ann.getFile()._obj
 
 
-def get_images_by_name(omero_obj):
+def get_children_by_name(omero_obj):
 
-    images_by_name={}
+    images_by_name = {}
+    wells_by_name = {}
 
     if omero_obj.OMERO_CLASS == "Dataset":
         for img in omero_obj.listChildren():
@@ -119,6 +119,8 @@ def get_images_by_name(omero_obj):
             images_by_name[img_name] = img
     elif omero_obj.OMERO_CLASS == "Plate":
         for well in omero_obj.listChildren():
+            label = well.getWellPos()
+            wells_by_name[label] = well
             for ws in well.listChildren():
                 img = ws.getImage()
                 img_name = img.getName()
@@ -129,7 +131,7 @@ def get_images_by_name(omero_obj):
     else:
         sys.stderr.write(f'{omero_obj.OMERO_CLASS} objects not supported')
 
-    return images_by_name
+    return images_by_name, wells_by_name
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -155,65 +157,101 @@ def populate_metadata(client, conn, script_params):
         data =list(csv.reader(file_handle, delimiter=','))
         file_handle.close()
 
-        # create a dictionary for image_name:id
-        images_by_name=get_images_by_name(target_object)
-        print("images_by_name", images_by_name.keys())
-
         # keys are in the header row
         header = data[0]
-        image_column_index = header.index("image")
-        if image_column_index == -1:
-            image_column_index = 0
+        print("header", header)
+
+        # create dictionaries for well/image name:object
+        images_by_name, wells_by_name = get_children_by_name(target_object)
+
+        image_index = header.index("image")
+        well_index = header.index("well")
+        plate_index = header.index("plate")
+        if image_index == -1:
+            # Use first column by default
+            image_index = 0
         # kv_data = header[1:]  # first header is the fimename columns
+        print("image_index:", image_index, "well_index:", well_index, "plate_index:", plate_index)
         rows = data[1:]
 
         nimg_updated = 0
-        for row in rows: # loop over images
-            img_name = row[image_column_index]
-            if( img_name not in images_by_name ):
-                print("Can't find filename : {}".format(img_name) )
-            else:
-                img = images_by_name[img_name]
-                print("Annotating image:", img.id, img.name)
+        # loop over csv rows...
+        for row in rows:
+            # try to find 'image', then 'well', then 'plate'
+            image_name = row[image_index]
+            well_name = None
+            plate_name = None
+            obj = None
+            if image_name in images_by_name:
+                obj = images_by_name[image_name]
+                print("Annotating Image:", obj.id, image_name)
+            elif well_index > -1:
+                well_name = row[well_index]
+                if row[well_index] in wells_by_name:
+                    obj = wells_by_name[well_name]
+                    print("Annotating Well:", obj.id, well_name)
+            if obj is None and plate_index > -1:
+                plate_name = row[plate_index]
+                if plate_name == target_object.name:
+                    obj = target_object
+                    print("Annotating Plate:", obj.id, plate_name)
+            if obj is None:
+                msg = f"Can't find image: {image_name}"
+                if well_name:
+                    msg += f" or well: {well_name}"
+                if plate_name:
+                    msg += f" or plate: {plate_name}"
+                print(msg)
+                continue
 
-                existing_kv = get_existing_map_annotations( img )
-                updated_kv  = copy.deepcopy(existing_kv)
-                print("Existing kv ")
-                for k,vset in existing_kv.items():
-                    print(type(vset),len(vset))
-                    for v in vset:
-                        print(k,v)
-
-                for i in range(1,len(row)):  # first entry is the filename
-                    key = header[i].strip()
-                    vals = row[i].strip().split(';')
-                    if( len(vals) > 0 ):
-                        for val in vals:
-                            if len(val)>0 : 
-                                if key not in updated_kv: updated_kv[key] = set()
-                                print("adding",key,val)
-                                updated_kv[key].add(val)
-
-                if( existing_kv != updated_kv ):
-                    nimg_updated = nimg_updated + 1
-                    print("The key-values pairs are different")
-                    remove_map_annotations( conn, 'Image', img.getId()  )
-                    map_ann = omero.gateway.MapAnnotationWrapper(conn)
-                    namespace = omero.constants.metadata.NSCLIENTMAPANNOTATION
-                    map_ann.setNs(namespace)
-                    # convert the ordered dict to a list of lists
-                    kv_list=[]
-                    for k,vset in updated_kv.items():
-                        for v in vset:
-                            kv_list.append( [k,v] )
-                    map_ann.setValue(kv_list)
-                    map_ann.save()
-                    print("Map Annotation created", map_ann.id)
-                    img.linkAnnotation(map_ann)
-                else:
-                    print("No change change in kv's")
+            updated = annotate_object(conn, obj, header, row)
+            if updated:
+                nimg_updated += 1
 
     return "Added {} kv pairs to {}/{} files  ".format(len(header)-1,nimg_updated,len(images_by_name))
+
+
+def annotate_object(conn, obj, header, row):
+
+    obj_updated = False
+    existing_kv = get_existing_map_annotations(obj)
+    updated_kv  = copy.deepcopy(existing_kv)
+    print("Existing kv:")
+    for k, vset in existing_kv.items():
+        for v in vset:
+            print("   ", k, v)
+
+    print("Adding kv:")
+    for i in range(1,len(row)):  # first entry is the filename
+        key = header[i].strip()
+        vals = row[i].strip().split(';')
+        if( len(vals) > 0 ):
+            for val in vals:
+                if len(val)>0 : 
+                    if key not in updated_kv: updated_kv[key] = set()
+                    print("   ", key, val)
+                    updated_kv[key].add(val)
+
+    if existing_kv != updated_kv:
+        obj_updated = True
+        print("The key-values pairs are different")
+        remove_map_annotations(conn, obj)
+        map_ann = omero.gateway.MapAnnotationWrapper(conn)
+        namespace = omero.constants.metadata.NSCLIENTMAPANNOTATION
+        map_ann.setNs(namespace)
+        # convert the ordered dict to a list of lists
+        kv_list=[]
+        for k,vset in updated_kv.items():
+            for v in vset:
+                kv_list.append( [k,v] )
+        map_ann.setValue(kv_list)
+        map_ann.save()
+        print("Map Annotation created", map_ann.id)
+        obj.linkAnnotation(map_ann)
+    else:
+        print("No change change in kv")
+
+    return obj_updated
 
 
 def run_script():

--- a/omero/annotation_scripts/KeyVal_from_csv.py
+++ b/omero/annotation_scripts/KeyVal_from_csv.py
@@ -182,25 +182,26 @@ def keyval_from_csv(conn, script_params):
             well_name = None
             plate_name = None
             obj = None
-            if image_name in images_by_name:
-                obj = images_by_name[image_name]
-                print("Annotating Image:", obj.id, image_name)
-            elif well_index > -1:
+            if len(image_name) > 0:
+                if image_name in images_by_name:
+                    obj = images_by_name[image_name]
+                    print("Annotating Image:", obj.id, image_name)
+                else:
+                    print("Image not found:", image_name)
+            if obj is None and well_index > -1 and len(row[well_index]) > 0:
                 well_name = row[well_index]
                 if well_name in wells_by_name:
                     obj = wells_by_name[well_name]
                     print("Annotating Well:", obj.id, well_name)
+                else:
+                    print("Well not found:", well_name)
             if obj is None and plate_index > -1:
                 plate_name = row[plate_index]
                 if plate_name == target_object.name:
                     obj = target_object
                     print("Annotating Plate:", obj.id, plate_name)
             if obj is None:
-                msg = f"Can't find image: {image_name}"
-                if well_name:
-                    msg = msg + f" or well: {well_name}"
-                if plate_name:
-                    msg = msg + f" or plate: {plate_name}"
+                msg = f"Can't find object by image, well or plate name"
                 print(msg)
                 continue
 


### PR DESCRIPTION
See discussion at https://forum.image.sc/t/uploading-key-value-pairs-from-csv-files-into-omero-web-for-plates/60202/27

This should annotate objects from a CSV, following the rules defined there, with plate, well, image columns:

```
plate           well    image               Cell line
Index.idx.xml                               S2R+        # add KV to plate
Index.idx.xml   B2                          S2R+        # add KV to well only
Index.idx.xml   B2      Well 1 Field 1      S2R+        # add KV to image only
Index.idx.xml           Well 1 Field 2      S2R+        # add KV to image only
```

To test:
 - create a CSV like the one above, with a mixture of rows that have plate, well or image names that match a Plate that you have
 - Select the Plate, run the script - You can now pick the csv using the script dialog file-picker (didn't work before)
 - The plate, well and image objects that match names in the CSV should be annotated, according to the rules above (1 object per row of the table)
 